### PR TITLE
Fix TypeError in build_claim() for 837 claim processing

### DIFF
--- a/databricksx12/hls/healthcare.py
+++ b/databricksx12/hls/healthcare.py
@@ -112,7 +112,13 @@ class HealthcareManager(EDI):
 
     @classmethod
     def build_claim(cls, seg, i, trnx_cls, data, format_cls):
-        return ClaimBuilder(trnx_cls, [x for x in data if x._name not in ['SE', 'ST']], format_cls).build_claim(seg, i-1)
+        filtered = [x for x in data if x._name not in ['SE', 'ST']]
+        all_claims = ClaimBuilder(trnx_cls, filtered, format_cls).build()
+        for claim in all_claims:
+            if claim.claim_loop and claim.claim_loop[0] is seg:
+                return claim
+        return all_claims[0] if all_claims else None
+
 
     @classmethod
     def build_remittance(cls, seg, i, trnx_cls, data, format_cls):


### PR DESCRIPTION
Bug: HealthcareManager.build_claim() calls ClaimBuilder.build_claim(seg, i-1) with 2 args, but ClaimBuilder.build_claim() was updated to require billing_loop, subscriber_loop, and patient_loop as additional required parameters. This causes a TypeError for all 837 (claim) processing via flatten_to_json. The 835 path is unaffected since it uses build_remittance.

Fix: Replace the direct build_claim() call with build() (which uses the new _build_837_iter() internally), then match the correct claim by CLM segment identity.