### PR TITLE
Enhance 834 MemberEnrollment field coverage (BGN/N1/REF/DTP/HD/LS-LE)

### DIFF
--- a/databricksx12/hls/claim.py
+++ b/databricksx12/hls/claim.py
@@ -68,9 +68,13 @@ class ClaimBuilder(EDI):
     def build_enrollment(self, pay_segment, idx):
         ins_next_idx = self.index_of_segment(self.data, "INS", idx+1)
         end_idx = ins_next_idx if ins_next_idx > 0 else self.index_of_segment(self.data, "SE")
-        
+        # Header (BGN/QTY/sponsor N1) lives before the first INS in the transaction
+        first_ins = self.index_of_segment(self.data, "INS")
+        header_end = first_ins if first_ins > 0 else 0
+
         return self.trnx_cls(
-            member_detail_loop = self.data[idx:end_idx]
+            member_detail_loop=self.data[idx:end_idx],
+            transaction_header_loop=self.data[0:header_end],
         )
 
     #
@@ -229,13 +233,20 @@ class ClaimBuilder(EDI):
             # Optimized: Pre-build index of all INS positions, then slice between them
             ins_indices = [i for i, seg in self.segments_by_name_index("INS")]
             se_idx = self.index_of_segment(self.data, "SE")
-            
+
+            # Header (BGN/QTY/sponsor-payer N1) is everything before the first INS
+            header_end = ins_indices[0] if ins_indices else 0
+            transaction_header_loop = self.data[0:header_end]
+
             # Add SE index as the end boundary
             ins_indices.append(se_idx if se_idx > 0 else len(self.data))
-            
+
             # Build enrollments by slicing between consecutive INS positions
             return [
-                self.trnx_cls(member_detail_loop=self.data[ins_indices[i]:ins_indices[i+1]])
+                self.trnx_cls(
+                    member_detail_loop=self.data[ins_indices[i]:ins_indices[i + 1]],
+                    transaction_header_loop=transaction_header_loop,
+                )
                 for i in range(len(ins_indices) - 1)
             ]
 

--- a/databricksx12/hls/enrollment.py
+++ b/databricksx12/hls/enrollment.py
@@ -3,7 +3,18 @@ from databricksx12.hls.claim import MedicalClaim
 
 
 class MemberEnrollment(MedicalClaim):
+    """
+    HIPAA 834 Benefit Enrollment and Maintenance (005010X220A1).
+
+    Grain: one MemberEnrollment per INS (member) loop.
+    Optional transaction_header_loop carries BGN / QTY / sponsor-payer N1
+    segments that appear before the first INS.
+    """
+
     NAME = "834"
+
+    # NM1 entity identifiers treated as the member/subscriber name
+    MEMBER_NM1_QUALIFIERS = ("IL", "74", "1")
 
     IDENTIFIER_TYPE_MAPPING = {
         "34": "Social Security Number (SSN)",
@@ -13,106 +24,486 @@ class MemberEnrollment(MedicalClaim):
         "EI": "Employer ID",
         "MI": "Member ID",
         "SY": "Social Security Number (Alt)",
-        "NI": "National Insurance Number"
+        "NI": "National Insurance Number",
+        "94": "Plan ID",
+        "SV": "Service Provider Number",
     }
 
     COVERAGE_DESC_MAPPING = {
         "HLT": "Health",
         "DEN": "Dental",
-        "VIS": "Vision"
+        "VIS": "Vision",
     }
 
-    def __init__(self, member_detail_loop):
-        self.member_detail_loop = member_detail_loop
+    MAINTENANCE_TYPE_MAPPING = {
+        "001": "Change",
+        "002": "Delete",
+        "021": "Addition",
+        "024": "Cancellation / Termination",
+        "025": "Reinstatement",
+        "030": "Audit / Compare",
+    }
+
+    RELATIONSHIP_MAPPING = {
+        "18": "Self",
+        "01": "Spouse",
+        "19": "Child",
+        "G8": "Other Relationship",
+    }
+
+    # Common 834 REF qualifiers (member / policy / group)
+    REF_QUALIFIER_MAPPING = {
+        "0F": "Subscriber Number",
+        "1L": "Group / Policy Number",
+        "17": "Client Reporting Category",
+        "23": "Client Number",
+        "3H": "Case Number",
+        "ABB": "Personal ID Number",
+        "ZZ": "Mutually Defined",
+        "X9": "Policy Number",
+        "9V": "Payment Category",
+    }
+
+    N1_ENTITY_MAPPING = {
+        "P5": "Plan Sponsor",
+        "IN": "Insurer",
+        "75": "Participant",
+    }
+
+    NM1_ENTITY_MAPPING = {
+        "IL": "Insured / Subscriber",
+        "74": "Corrected Insured",
+        "70": "Prior Incorrect Insured",
+        "QD": "Responsible Party",
+        "Y2": "Managed Care Organization",
+        "1": "Person",
+    }
+
+    # Member-level DTP qualifiers (not plan HD dates)
+    MEMBER_DTP_MAPPING = {
+        "303": "Maintenance Effective",
+        "356": "Eligibility Begin",
+        "357": "Eligibility End",
+        "338": "Medicare Begin",
+        "339": "Medicare End",
+        "340": "COBRA Begin",
+        "341": "COBRA End",
+        "342": "Premium Paid To Date Begin",
+        "343": "Premium Paid To Date End",
+        "300": "Enrollment Signature Date",
+        "301": "Issue / Recertification",
+    }
+
+    def __init__(self, member_detail_loop, transaction_header_loop=None):
+        self.member_detail_loop = member_detail_loop or []
+        self.transaction_header_loop = transaction_header_loop or []
         self.enrollment_data = self.build_enrollment_data()
 
-    def build_plan_elections(self, segments):
-        # Build local index for O(1) lookups
+    # ------------------------------------------------------------------
+    # helpers
+    # ------------------------------------------------------------------
+    @staticmethod
+    def _index_segments(segments):
         segment_index = {}
         for x in segments:
-            if x._name not in segment_index:
-                segment_index[x._name] = []
-            segment_index[x._name].append(x)
-            
-        def get_dtp(qualifier):
-            found = [x for x in segment_index.get("DTP", []) if x.element(1) == qualifier]
-            return found[0] if found else Segment.empty()
-            
-        dtp_348 = get_dtp("348")
-        dtp_349 = get_dtp("349")
-        dtp_344 = get_dtp("344")
-        dtp_345 = get_dtp("345")
-        
-        cob = segment_index.get("COB", [Segment.empty()])[0]
+            segment_index.setdefault(x._name, []).append(x)
+        return segment_index
 
-        return {
-            'coverage_type_code': segments[0].element(3), #first segment is always HD
-            'coverage_desc':  self.COVERAGE_DESC_MAPPING.get(segments[0].element(3), "Unknown"),
-            'coverage_start_dt': dtp_348.element(3),
-            'coverage_start_dt_format': dtp_348.element(2),
-            'coverage_end_dt': dtp_349.element(3),
-            'coverage_end_dt_format': dtp_349.element(2),
-            'cob_payer_responsible_cd': cob.element(1),
-            'cob_policy_number': cob.element(2),   
-            'cob_indicator_cd': cob.element(3), 
-            'cob_service_type_cd': cob.element(4), 
-            'cob_start_dt': dtp_344.element(3),
-            'cob_start_dt_format': dtp_344.element(2),
-            'cob_end_dt': dtp_345.element(3),
-            'cob_end_dt_format': dtp_345.element(2),
+    @staticmethod
+    def _get_first(segment_index, name):
+        return segment_index.get(name, [Segment.empty()])[0]
+
+    @staticmethod
+    def _get_dtp(segment_index, qualifier):
+        found = [x for x in segment_index.get("DTP", []) if x.element(1) == qualifier]
+        return found[0] if found else Segment.empty()
+
+    @classmethod
+    def _ref_list(cls, segments):
+        refs = []
+        for seg in segments:
+            if seg._name != "REF":
+                continue
+            qual = seg.element(1)
+            refs.append(
+                {
+                    "ref_qualifier": qual,
+                    "ref_qualifier_desc": cls.REF_QUALIFIER_MAPPING.get(qual, qual),
+                    "ref_value": seg.element(2),
+                    "ref_description": seg.element(3),
+                }
+            )
+        return refs
+
+    @classmethod
+    def _dtp_list(cls, segments, mapping=None):
+        mapping = mapping or {}
+        out = []
+        for seg in segments:
+            if seg._name != "DTP":
+                continue
+            qual = seg.element(1)
+            out.append(
+                {
+                    "dtp_qualifier": qual,
+                    "dtp_qualifier_desc": mapping.get(qual, qual),
+                    "dtp_format": seg.element(2),
+                    "dtp_date": seg.element(3),
+                }
+            )
+        return out
+
+    def _find_member_nm1(self, segments):
+        nm1s = [s for s in segments if s._name == "NM1"]
+        for qual in self.MEMBER_NM1_QUALIFIERS:
+            for seg in nm1s:
+                if seg.element(1) == qual:
+                    return seg
+        return nm1s[0] if nm1s else Segment.empty()
+
+    def _parse_contact_phones(self, per):
+        """
+        PER communication numbers are qualifier/value pairs starting at element 3.
+        Supports HP/TE (home/telephone), WP (work), EM (email), etc.
+        """
+        phones = {
+            "home_phone": "",
+            "work_phone": "",
+            "other_phone": "",
+            "email": "",
         }
-    
-    def build_enrollment_data(self):
-        # Build local index for O(1) lookups
-        segment_index = {}
-        for x in self.member_detail_loop:
-            if x._name not in segment_index:
-                segment_index[x._name] = []
-            segment_index[x._name].append(x)
-            
-        def get_first(name):
-            return segment_index.get(name, [Segment.empty()])[0]
+        # Walk PER03/PER04, PER05/PER06, PER07/PER08
+        for i in range(3, 9, 2):
+            qual = per.element(i)
+            val = per.element(i + 1)
+            if not qual:
+                continue
+            if qual in ("HP", "TE"):
+                if not phones["home_phone"]:
+                    phones["home_phone"] = val
+                else:
+                    phones["other_phone"] = val
+            elif qual == "WP":
+                phones["work_phone"] = val
+            elif qual == "EM":
+                phones["email"] = val
+            elif not phones["other_phone"]:
+                phones["other_phone"] = val
+        return phones
 
-        nm1 = get_first("NM1")
-        dmg = get_first("DMG")
-        per = get_first("PER")
-        n3 = get_first("N3")
-        n4 = get_first("N4")
-        ins = get_first("INS")
-        dtp = get_first("DTP")
-        
-        hd_idx = [i for i, seg in self.segments_by_name_index("HD", data=self.member_detail_loop)] + [len(self.member_detail_loop)]
+    def _parse_n1_party(self, n1):
+        entity = n1.element(1)
+        id_qual = n1.element(3)
+        return {
+            "entity_identifier_code": entity,
+            "entity_identifier_desc": self.N1_ENTITY_MAPPING.get(entity, entity),
+            "name": n1.element(2),
+            "id_code_qualifier": id_qual,
+            "id_code_qualifier_desc": self.IDENTIFIER_TYPE_MAPPING.get(id_qual, id_qual),
+            "id_code": n1.element(4),
+        }
+
+    def _parse_nm1_person(self, nm1, dmg=None):
+        entity = nm1.element(1)
+        id_qual = nm1.element(8)
+        person = {
+            "entity_identifier_code": entity,
+            "entity_identifier_desc": self.NM1_ENTITY_MAPPING.get(entity, entity),
+            "entity_type": nm1.element(2),  # 1=person, 2=non-person
+            "last_name_or_org": nm1.element(3),
+            "first_name": nm1.element(4),
+            "middle_name": nm1.element(5),
+            "id_code_qualifier": id_qual,
+            "id_code_qualifier_desc": self.IDENTIFIER_TYPE_MAPPING.get(id_qual, id_qual),
+            "id_code": nm1.element(9),
+        }
+        if dmg is not None and dmg._name == "DMG":
+            person["dob"] = dmg.element(2)
+            person["gender"] = dmg.element(3)
+        return person
+
+    def build_transaction_header(self):
+        segs = self.transaction_header_loop
+        if not segs:
+            return {}
+
+        idx = self._index_segments(segs)
+        bgn = self._get_first(idx, "BGN")
+        qty = self._get_first(idx, "QTY")
+
+        sponsors = []
+        insurers = []
+        other_parties = []
+        for n1 in idx.get("N1", []):
+            party = self._parse_n1_party(n1)
+            if n1.element(1) == "P5":
+                sponsors.append(party)
+            elif n1.element(1) == "IN":
+                insurers.append(party)
+            else:
+                other_parties.append(party)
+
+        header = {
+            "bgn_purpose_code": bgn.element(1),
+            "bgn_reference_id": bgn.element(2),
+            "bgn_date": bgn.element(3),
+            "bgn_time": bgn.element(4),
+            "bgn_action_code": bgn.element(8),
+            "qty_qualifier": qty.element(1),
+            "qty_value": qty.element(2),
+            "sponsors": sponsors,
+            "insurers": insurers,
+        }
+        if other_parties:
+            header["other_parties"] = other_parties
+        return header
+
+    def build_plan_elections(self, segments):
+        # Truncate election loop before reporting / nested LX that are not HD children
+        trimmed = []
+        for seg in segments:
+            if seg._name in ("LS", "LE") or (
+                seg._name == "LX" and trimmed and trimmed[0]._name == "HD"
+            ):
+                # LX after HD content ends the plan election for v1
+                # (Medicaid files put reporting LX after all HD loops)
+                break
+            trimmed.append(seg)
+        if not trimmed:
+            trimmed = segments
+
+        segment_index = self._index_segments(trimmed)
+        hd = trimmed[0] if trimmed else Segment.empty()
+
+        dtp_348 = self._get_dtp(segment_index, "348")
+        dtp_349 = self._get_dtp(segment_index, "349")
+        dtp_344 = self._get_dtp(segment_index, "344")
+        dtp_345 = self._get_dtp(segment_index, "345")
+        cob = self._get_first(segment_index, "COB")
+
+        coverage_type = hd.element(3)
+        return {
+            "maintenance_type_code": hd.element(1),
+            "coverage_type_code": coverage_type,
+            "coverage_desc": self.COVERAGE_DESC_MAPPING.get(coverage_type, "Unknown"),
+            "plan_coverage_description": hd.element(4),
+            "coverage_level_code": hd.element(5),  # e.g. IND, FAM
+            "coverage_start_dt": dtp_348.element(3),
+            "coverage_start_dt_format": dtp_348.element(2),
+            "coverage_end_dt": dtp_349.element(3),
+            "coverage_end_dt_format": dtp_349.element(2),
+            "references": self._ref_list(trimmed),
+            "cob_payer_responsible_cd": cob.element(1),
+            "cob_policy_number": cob.element(2),
+            "cob_indicator_cd": cob.element(3),
+            "cob_service_type_cd": cob.element(4),
+            "cob_start_dt": dtp_344.element(3),
+            "cob_start_dt_format": dtp_344.element(2),
+            "cob_end_dt": dtp_345.element(3),
+            "cob_end_dt_format": dtp_345.element(2),
+        }
+
+    def _health_coverage_elections(self):
+        """Slice HD loops; stop before LS/LE reporting or trailing LX reporting blocks."""
+        loop = self.member_detail_loop
+        hd_positions = [i for i, seg in enumerate(loop) if seg._name == "HD"]
+        if not hd_positions:
+            return []
+
+        # End boundary: next HD, or first LS/LE after this HD, or first LX that
+        # appears after the last HD's immediate children... Use LS/LE/end as hard stops.
+        hard_stops = [
+            i for i, seg in enumerate(loop) if seg._name in ("LS", "LE")
+        ]
+        elections = []
+        for i, start in enumerate(hd_positions):
+            next_hd = hd_positions[i + 1] if i + 1 < len(hd_positions) else len(loop)
+            stop_candidates = [next_hd] + [s for s in hard_stops if s > start]
+            end = min(stop_candidates)
+            elections.append(self.build_plan_elections(loop[start:end]))
+        return elections
+
+    def _related_parties(self, member_nm1):
+        """NM1(+optional DMG) entities other than the primary member."""
+        parties = []
+        loop = self.member_detail_loop
+        first_hd = next((j for j, s in enumerate(loop) if s._name == "HD"), len(loop))
+
+        i = 0
+        while i < len(loop):
+            seg = loop[i]
+            if seg._name != "NM1":
+                i += 1
+                continue
+
+            is_member = (
+                seg is member_nm1
+                or (
+                    seg.element(1) == member_nm1.element(1)
+                    and seg.element(9) == member_nm1.element(9)
+                    and seg.element(3) == member_nm1.element(3)
+                )
+            )
+            # Keep pre-HD related names (70/QD/…) and post-HD Y2 (MCO) entities
+            keep = (not is_member) and (i < first_hd or seg.element(1) == "Y2")
+            if keep:
+                dmg = loop[i + 1] if i + 1 < len(loop) and loop[i + 1]._name == "DMG" else None
+                parties.append(self._parse_nm1_person(seg, dmg))
+            i += 1
+        return parties
+
+    def _member_reporting_categories(self):
+        """
+        Parse LS/LE*2700 style reporting categories common in Medicaid 834s:
+        LX*n ~ N1*75*NAME ~ REF*.. ~ DTP*..
+        """
+        loop = self.member_detail_loop
+        try:
+            ls_idx = next(
+                i
+                for i, s in enumerate(loop)
+                if s._name == "LS" and s.element(1) == "2700"
+            )
+        except StopIteration:
+            return []
+
+        try:
+            le_idx = next(
+                i
+                for i, s in enumerate(loop)
+                if i > ls_idx and s._name == "LE" and s.element(1) == "2700"
+            )
+        except StopIteration:
+            le_idx = len(loop)
+
+        block = loop[ls_idx + 1 : le_idx]
+        categories = []
+        current = None
+        for seg in block:
+            if seg._name == "LX":
+                if current:
+                    categories.append(current)
+                current = {
+                    "assigned_number": seg.element(1),
+                    "name": "",
+                    "references": [],
+                    "dates": [],
+                }
+            elif seg._name == "N1" and current is not None:
+                current["name"] = seg.element(2)
+                current["entity_identifier_code"] = seg.element(1)
+            elif seg._name == "REF" and current is not None:
+                qual = seg.element(1)
+                current["references"].append(
+                    {
+                        "ref_qualifier": qual,
+                        "ref_qualifier_desc": self.REF_QUALIFIER_MAPPING.get(qual, qual),
+                        "ref_value": seg.element(2),
+                    }
+                )
+            elif seg._name == "DTP" and current is not None:
+                current["dates"].append(
+                    {
+                        "dtp_qualifier": seg.element(1),
+                        "dtp_format": seg.element(2),
+                        "dtp_date": seg.element(3),
+                    }
+                )
+        if current:
+            categories.append(current)
+        return categories
+
+    def build_enrollment_data(self):
+        loop = self.member_detail_loop
+        segment_index = self._index_segments(loop)
+
+        ins = self._get_first(segment_index, "INS")
+        member_nm1 = self._find_member_nm1(loop)
+
+        # DMG that follows the member NM1 (not a related-party DMG)
+        dmg = Segment.empty()
+        try:
+            nm1_pos = next(i for i, s in enumerate(loop) if s is member_nm1)
+            for s in loop[nm1_pos + 1 :]:
+                if s._name == "DMG":
+                    dmg = s
+                    break
+                if s._name in ("NM1", "HD", "INS"):
+                    break
+        except StopIteration:
+            dmg = self._get_first(segment_index, "DMG")
+
+        per = self._get_first(segment_index, "PER")
+        n3 = self._get_first(segment_index, "N3")
+        n4 = self._get_first(segment_index, "N4")
+
+        # Member-level segments only (before first HD)
+        first_hd = next((i for i, s in enumerate(loop) if s._name == "HD"), len(loop))
+        member_level = loop[:first_hd]
+
+        maint_type = ins.element(3)
+        relationship = ins.element(2)
+        id_qual = member_nm1.element(8)
+
+        dtp_356 = self._get_dtp(self._index_segments(member_level), "356")
+        dtp_303 = self._get_dtp(self._index_segments(member_level), "303")
+        # Prefer eligibility begin; fall back to maintenance effective; then any DTP
+        coverage_start = (
+            dtp_356.element(3)
+            or dtp_303.element(3)
+            or self._get_first(self._index_segments(member_level), "DTP").element(3)
+        )
 
         return {
-                "member_id_code": nm1.element(9),
-                "member_identifier_type": self.IDENTIFIER_TYPE_MAPPING.get(nm1.element(8), nm1.element(8)),
-                "member_first_name": nm1.element(4),
-                "member_last_name": nm1.element(3),
-                "member_dob": dmg.element(2),
-                "member_gender": dmg.element(3),
-                "contact_phone_number": {
-                    "home_phone": per.element(4),
-                    "work_phone": per.element(6)
-                },
-                "address": {
-                    "street_name": n3.element(1),
-                    "apartment_name": n3.element(2),
-                    "city_name": n4.element(1),
-                    "state_code": n4.element(2),
-                    "postal_code": n4.element(3)
-                },
-                "Maintenance": {
-                    "benefit_status": ins.element(1),
-                    "maintenance_type_code": ins.element(3),
-                    "maintenance_reason_code": ins.element(4),
-                    "coverage_start_date" : dtp.element(3)
-                },
-                "health_coverage_elections": [
-                    self.build_plan_elections(self.member_detail_loop[t[0]:t[1]]) for t in zip(hd_idx, hd_idx[1:])
-                ]
+            "transaction_header": self.build_transaction_header(),
+            "member_id_code": member_nm1.element(9),
+            "member_identifier_type": self.IDENTIFIER_TYPE_MAPPING.get(id_qual, id_qual),
+            "member_identifier_qualifier": id_qual,
+            "member_nm1_entity_code": member_nm1.element(1),
+            "member_nm1_entity_desc": self.NM1_ENTITY_MAPPING.get(
+                member_nm1.element(1), member_nm1.element(1)
+            ),
+            "member_first_name": member_nm1.element(4),
+            "member_last_name": member_nm1.element(3),
+            "member_middle_name": member_nm1.element(5),
+            "member_dob": dmg.element(2),
+            "member_gender": dmg.element(3),
+            "contact_phone_number": self._parse_contact_phones(per),
+            "address": {
+                "street_name": n3.element(1),
+                "apartment_name": n3.element(2),
+                "city_name": n4.element(1),
+                "state_code": n4.element(2),
+                "postal_code": n4.element(3),
+                "country_code": n4.element(4),
+                "location_qualifier": n4.element(5),
+                "location_identifier": n4.element(6),
+            },
+            "references": self._ref_list(member_level),
+            "member_dates": self._dtp_list(member_level, self.MEMBER_DTP_MAPPING),
+            "Maintenance": {
+                "benefit_status": ins.element(1),
+                "individual_relationship_code": relationship,
+                "individual_relationship_desc": self.RELATIONSHIP_MAPPING.get(
+                    relationship, relationship
+                ),
+                "maintenance_type_code": maint_type,
+                "maintenance_type_desc": self.MAINTENANCE_TYPE_MAPPING.get(
+                    maint_type, maint_type
+                ),
+                "maintenance_reason_code": ins.element(4),
+                "benefit_status_code": ins.element(5),
+                "medicare_plan_code": ins.element(6),
+                "cobra_qualifying_event": ins.element(7),
+                "employment_status_code": ins.element(8),
+                "coverage_start_date": coverage_start,
+                "maintenance_effective_date": dtp_303.element(3),
+                "eligibility_begin_date": dtp_356.element(3),
+            },
+            "related_parties": self._related_parties(member_nm1),
+            "health_coverage_elections": self._health_coverage_elections(),
+            "reporting_categories": self._member_reporting_categories(),
         }
 
     def to_json(self):
-        return {
-            'enrollment_member': self.enrollment_data
-        }
+        return {"enrollment_member": self.enrollment_data}

--- a/doc/Enrollment834_Field_Mapping.csv
+++ b/doc/Enrollment834_Field_Mapping.csv
@@ -1,22 +1,67 @@
 JSON_Field_Path,Loop_Name,Segment_Name,Element_Number,Element_Description,Notes
-enrollment_member.enrollment_member.member_id_code,2000,NM1,9,Identification Code,Member ID
-enrollment_member.enrollment_member.member_identifier_type,2000,NM1,8,Identification Code Qualifier,See IDENTIFIER_TYPE_MAPPING
-enrollment_member.enrollment_member.member_first_name,2000,NM1,4,Name First,First name
-enrollment_member.enrollment_member.member_last_name,2000,NM1,3,Name Last,Last name
-enrollment_member.enrollment_member.member_dob,2000,DMG,2,Date Time Period,Date of birth
-enrollment_member.enrollment_member.member_gender,2000,DMG,3,Gender Code,M=Male, F=Female
-enrollment_member.enrollment_member.contact_phone_number.home_phone,2000,PER,4,Communication Number,Home phone number
-enrollment_member.enrollment_member.contact_phone_number.work_phone,2000,PER,6,Communication Number,Work phone number
-enrollment_member.enrollment_member.address.street_name,2000,N3,1,Address Information,Street address
-enrollment_member.enrollment_member.address.apartment_name,2000,N3,2,Address Information,Apartment/suite
-enrollment_member.enrollment_member.address.city_name,2000,N4,1,City Name,City
-enrollment_member.enrollment_member.address.state_code,2000,N4,2,State or Province Code,State code
-enrollment_member.enrollment_member.address.postal_code,2000,N4,3,Postal Code,ZIP code
-enrollment_member.enrollment_member.Maintenance.benefit_status,2000,INS,1,Benefit Status Code,Y=Active, N=Inactive
-enrollment_member.enrollment_member.Maintenance.maintenance_type_code,2000,INS,3,Maintenance Type Code,See X12 834 spec
-enrollment_member.enrollment_member.Maintenance.maintenance_reason_code,2000,INS,4,Maintenance Reason Code,See X12 834 spec
-enrollment_member.enrollment_member.Maintenance.coverage_start_date,2000,DTP,3,Date Time Period,Coverage start date
-health_plan.coverage_type_code,2300,HD,3,Maintenance Type Code,HLT=Health, DEN=Dental, VIS=Vision
-health_plan.coverage_desc,2300,HD,3,Maintenance Type Code,See COVERAGE_DESC_MAPPING
-health_plan.effective_date,2300,DTP,3,Date Time Period,Effective date
-health_plan.end_date,2300,DTP,4,Date Time Period,End date (if present) 
+enrollment_member.transaction_header.bgn_purpose_code,Header,BGN,1,Transaction Set Purpose Code,00=Original
+enrollment_member.transaction_header.bgn_reference_id,Header,BGN,2,Reference Identification,File / batch reference
+enrollment_member.transaction_header.bgn_date,Header,BGN,3,Date,BGN date
+enrollment_member.transaction_header.bgn_time,Header,BGN,4,Time,BGN time
+enrollment_member.transaction_header.bgn_action_code,Header,BGN,8,Action Code,2=Change (typical)
+enrollment_member.transaction_header.qty_qualifier,Header,QTY,1,Quantity Qualifier,TO=Total
+enrollment_member.transaction_header.qty_value,Header,QTY,2,Quantity,Declared member count
+enrollment_member.transaction_header.sponsors[].entity_identifier_code,1000A,N1,1,Entity Identifier Code,P5=Plan Sponsor
+enrollment_member.transaction_header.sponsors[].name,1000A,N1,2,Name,Sponsor name
+enrollment_member.transaction_header.sponsors[].id_code_qualifier,1000A,N1,3,Identification Code Qualifier,FI/94/etc
+enrollment_member.transaction_header.sponsors[].id_code,1000A,N1,4,Identification Code,Sponsor tax/plan ID
+enrollment_member.transaction_header.insurers[].entity_identifier_code,1000B,N1,1,Entity Identifier Code,IN=Insurer
+enrollment_member.transaction_header.insurers[].name,1000B,N1,2,Name,Insurer name
+enrollment_member.transaction_header.insurers[].id_code_qualifier,1000B,N1,3,Identification Code Qualifier,
+enrollment_member.transaction_header.insurers[].id_code,1000B,N1,4,Identification Code,Insurer ID
+enrollment_member.member_id_code,2000,NM1,9,Identification Code,Member ID (IL/74 preferred)
+enrollment_member.member_identifier_qualifier,2000,NM1,8,Identification Code Qualifier,Raw qualifier
+enrollment_member.member_identifier_type,2000,NM1,8,Identification Code Qualifier,See IDENTIFIER_TYPE_MAPPING
+enrollment_member.member_nm1_entity_code,2000,NM1,1,Entity Identifier Code,IL/74/etc
+enrollment_member.member_first_name,2000,NM1,4,Name First,First name
+enrollment_member.member_last_name,2000,NM1,3,Name Last,Last name
+enrollment_member.member_middle_name,2000,NM1,5,Name Middle,Middle name / initial
+enrollment_member.member_dob,2000,DMG,2,Date Time Period,Date of birth
+enrollment_member.member_gender,2000,DMG,3,Gender Code,M/F/U
+enrollment_member.contact_phone_number.home_phone,2000,PER,4,Communication Number,HP or TE
+enrollment_member.contact_phone_number.work_phone,2000,PER,6,Communication Number,WP
+enrollment_member.contact_phone_number.email,2000,PER,,Communication Number,EM qualifier
+enrollment_member.address.street_name,2000,N3,1,Address Information,Street address
+enrollment_member.address.apartment_name,2000,N3,2,Address Information,Apartment/suite
+enrollment_member.address.city_name,2000,N4,1,City Name,City
+enrollment_member.address.state_code,2000,N4,2,State or Province Code,State
+enrollment_member.address.postal_code,2000,N4,3,Postal Code,ZIP
+enrollment_member.address.country_code,2000,N4,4,Country Code,Optional
+enrollment_member.address.location_qualifier,2000,N4,5,Location Qualifier,e.g. CY=County
+enrollment_member.address.location_identifier,2000,N4,6,Location Identifier,County name/code
+enrollment_member.references[].ref_qualifier,2000,REF,1,Reference Identification Qualifier,0F/1L/17/23/ZZ/...
+enrollment_member.references[].ref_value,2000,REF,2,Reference Identification,Reference value
+enrollment_member.member_dates[].dtp_qualifier,2000,DTP,1,Date/Time Qualifier,303/356/...
+enrollment_member.member_dates[].dtp_date,2000,DTP,3,Date Time Period,Date value
+enrollment_member.Maintenance.benefit_status,2000,INS,1,Yes/No Condition or Response Code,Y/N
+enrollment_member.Maintenance.individual_relationship_code,2000,INS,2,Individual Relationship Code,18=Self
+enrollment_member.Maintenance.individual_relationship_desc,2000,INS,2,Individual Relationship Code,Decoded
+enrollment_member.Maintenance.maintenance_type_code,2000,INS,3,Maintenance Type Code,021=Add 001=Change 024=Term
+enrollment_member.Maintenance.maintenance_type_desc,2000,INS,3,Maintenance Type Code,Decoded
+enrollment_member.Maintenance.maintenance_reason_code,2000,INS,4,Maintenance Reason Code,
+enrollment_member.Maintenance.benefit_status_code,2000,INS,5,Benefit Status Code,A=Active
+enrollment_member.Maintenance.employment_status_code,2000,INS,8,Employment Status Code,FT/AC/...
+enrollment_member.Maintenance.coverage_start_date,2000,DTP,3,Date Time Period,Prefers 356 then 303
+enrollment_member.Maintenance.maintenance_effective_date,2000,DTP,3,Date Time Period,DTP*303
+enrollment_member.Maintenance.eligibility_begin_date,2000,DTP,3,Date Time Period,DTP*356
+enrollment_member.related_parties[].entity_identifier_code,2000,NM1,1,Entity Identifier Code,70/QD/Y2/...
+enrollment_member.related_parties[].last_name_or_org,2000,NM1,3,Name Last or Organization Name,
+enrollment_member.related_parties[].first_name,2000,NM1,4,Name First,
+enrollment_member.related_parties[].dob,2000,DMG,2,Date Time Period,If DMG follows NM1
+enrollment_member.health_coverage_elections[].maintenance_type_code,2300,HD,1,Maintenance Type Code,HD maintenance
+enrollment_member.health_coverage_elections[].coverage_type_code,2300,HD,3,Insurance Line Code,HLT/DEN/VIS
+enrollment_member.health_coverage_elections[].coverage_desc,2300,HD,3,Insurance Line Code,Decoded
+enrollment_member.health_coverage_elections[].coverage_level_code,2300,HD,5,Coverage Level Code,IND/FAM
+enrollment_member.health_coverage_elections[].coverage_start_dt,2300,DTP,3,Date Time Period,DTP*348
+enrollment_member.health_coverage_elections[].coverage_end_dt,2300,DTP,3,Date Time Period,DTP*349
+enrollment_member.health_coverage_elections[].references[].ref_value,2300,REF,2,Reference Identification,e.g. X9 policy ID
+enrollment_member.health_coverage_elections[].cob_payer_responsible_cd,2320,COB,1,Payer Responsibility Sequence Number Code,
+enrollment_member.health_coverage_elections[].cob_policy_number,2320,COB,2,Reference Identification,
+enrollment_member.reporting_categories[].name,2700,N1,2,Name,LS/LE 2700 reporting
+enrollment_member.reporting_categories[].references[].ref_value,2700,REF,2,Reference Identification,Category value
+enrollment_member.reporting_categories[].dates[].dtp_date,2700,DTP,3,Date Time Period,Category date

--- a/setup.py
+++ b/setup.py
@@ -8,13 +8,13 @@ with open(path.join(this_directory, "README.md"), encoding="utf-8") as f:
     LONG_DESCRIPTION = f.read()
 
 setup(
-    name="databricksx12",
-    version="0.0.9",
-    # python_requires='>=3.9.*',
-    python_requires='>=3.9',
-    author="Aaron Zavora, Raven Mukherjee",
-    author_email="aaron.zavora@databricks.com",
-    description= "Parser for handling x12 EDI transactions in Spark",
+ name="databricksx12",
+ version="0.0.10a1",
+ # python_requires='>=3.9.*',
+ python_requires='>=3.9',
+ author="Aaron Zavora, Raven Mukherjee",
+ author_email="aaron.zavora@databricks.com",
+ description= "Parser for handling x12 EDI transactions in Spark",
     long_description=LONG_DESCRIPTION,
     long_description_content_type="text/markdown",
     url="https://github.com/databricks-industry-solutions/x12-edi-parser",

--- a/tests/test_enrollment_fields.py
+++ b/tests/test_enrollment_fields.py
@@ -1,0 +1,153 @@
+"""
+Field-level 834 enrollment tests (no Spark required).
+
+Validates that both accelerator sample files map the v1 field set:
+header (BGN/QTY/N1), member REFs/DTPs, INS maintenance, related parties,
+plan elections, and LS/LE 2700 reporting categories when present.
+"""
+import json
+import os
+import unittest
+
+from ember import EDI
+from ember.hls.healthcare import HealthcareManager as hm
+
+
+SAMPLE_DIR = os.path.join(os.path.dirname(__file__), "..", "sampledata", "834")
+
+
+def _load(name):
+    path = os.path.join(SAMPLE_DIR, name)
+    with open(path, "rb") as f:
+        return EDI(f.read().decode("utf-8"), strict_transactions=False)
+
+
+class TestEnrollmentFields(unittest.TestCase):
+
+    def test_edi_834_classic_addition(self):
+        members = hm.from_edi(_load("EDI_834.txt"))
+        self.assertEqual(len(members), 1)
+        data = members[0].to_json()["enrollment_member"]
+
+        # Header / sponsor
+        hdr = data["transaction_header"]
+        self.assertEqual(hdr["bgn_purpose_code"], "00")
+        self.assertEqual(hdr["bgn_reference_id"], "12456")
+        self.assertEqual(hdr["sponsors"][0]["entity_identifier_code"], "P5")
+        self.assertEqual(hdr["sponsors"][0]["id_code"], "999888777")
+        self.assertEqual(hdr["insurers"][0]["entity_identifier_code"], "IN")
+        self.assertEqual(hdr["insurers"][0]["id_code"], "654456654")
+
+        # Member
+        self.assertEqual(data["member_last_name"], "DOE")
+        self.assertEqual(data["member_first_name"], "JOHN")
+        self.assertEqual(data["member_id_code"], "123456789")
+        self.assertEqual(data["member_nm1_entity_code"], "IL")
+        self.assertEqual(data["address"]["city_name"], "CAMP HILL")
+        self.assertEqual(data["address"]["location_qualifier"], "CY")
+        self.assertEqual(data["address"]["location_identifier"], "CUMBERLAND")
+        self.assertEqual(data["contact_phone_number"]["home_phone"], "7172343334")
+        self.assertEqual(data["contact_phone_number"]["work_phone"], "7172341240")
+
+        # REFs
+        ref_map = {r["ref_qualifier"]: r["ref_value"] for r in data["references"]}
+        self.assertEqual(ref_map["0F"], "123456789")
+        self.assertEqual(ref_map["1L"], "123456001")
+
+        # Maintenance
+        maint = data["Maintenance"]
+        self.assertEqual(maint["maintenance_type_code"], "021")
+        self.assertEqual(maint["maintenance_type_desc"], "Addition")
+        self.assertEqual(maint["individual_relationship_code"], "18")
+        self.assertEqual(maint["individual_relationship_desc"], "Self")
+        self.assertEqual(maint["maintenance_reason_code"], "20")
+        self.assertEqual(maint["benefit_status_code"], "A")
+        self.assertEqual(maint["employment_status_code"], "FT")
+        self.assertEqual(maint["eligibility_begin_date"], "19960523")
+        self.assertEqual(maint["coverage_start_date"], "19960523")
+
+        # Elections
+        elections = data["health_coverage_elections"]
+        self.assertEqual(len(elections), 3)
+        types = [e["coverage_type_code"] for e in elections]
+        self.assertEqual(types, ["HLT", "DEN", "VIS"])
+        self.assertEqual(elections[0]["cob_policy_number"], "890111")
+        self.assertEqual(elections[0]["coverage_start_dt"], "19960601")
+
+        # No Medicaid reporting loop on this file
+        self.assertEqual(data["reporting_categories"], [])
+
+    def test_834_test_medicaid_style(self):
+        members = hm.from_edi(_load("834_test.txt"))
+        self.assertEqual(len(members), 1)
+        data = members[0].to_json()["enrollment_member"]
+
+        hdr = data["transaction_header"]
+        self.assertEqual(hdr["qty_qualifier"], "TO")
+        self.assertEqual(hdr["qty_value"], "1")
+        self.assertEqual(hdr["sponsors"][0]["name"], "MEDICAID")
+        self.assertEqual(hdr["sponsors"][0]["id_code"], "141797357")
+        self.assertEqual(hdr["insurers"][0]["id_code"], "8-DIGIT PLAN ID")
+
+        self.assertEqual(data["member_nm1_entity_code"], "74")
+        self.assertEqual(data["member_last_name"], "SUBSCRIBER B LAST NAME")
+        self.assertEqual(data["member_first_name"], "SUBSCRIBER B FIRST NAME")
+        self.assertEqual(data["member_id_code"], "299999992")
+        self.assertEqual(data["contact_phone_number"]["home_phone"], "9999999999")
+
+        ref_map = {r["ref_qualifier"]: r["ref_value"] for r in data["references"]}
+        self.assertEqual(ref_map["0F"], "XX29992X")
+        self.assertEqual(ref_map["1L"], "HEALTH PLAN GROUP NUM")
+        self.assertEqual(ref_map["17"], "XX29992X")
+        self.assertEqual(ref_map["23"], "PLAN ASSIGNED MEMBER ID")
+        self.assertEqual(ref_map["ZZ"], "PLAN ASSIGNED SUBSCRIBER ID")
+
+        maint = data["Maintenance"]
+        self.assertEqual(maint["maintenance_type_code"], "001")
+        self.assertEqual(maint["maintenance_type_desc"], "Change")
+        self.assertEqual(maint["maintenance_effective_date"], "20240724")
+        self.assertEqual(maint["eligibility_begin_date"], "20240701")
+        self.assertEqual(maint["coverage_start_date"], "20240701")  # prefers 356
+        self.assertEqual(maint["employment_status_code"], "AC")
+
+        # Related parties (70 + QD) before HD
+        entities = {p["entity_identifier_code"]: p for p in data["related_parties"]}
+        self.assertIn("70", entities)
+        self.assertEqual(entities["70"]["last_name_or_org"], "SUBSCRIBER B1 LAST NAME")
+        self.assertEqual(entities["70"]["dob"], "20010101")
+        self.assertIn("QD", entities)
+        self.assertEqual(entities["QD"]["last_name_or_org"], "CASE NAME")
+
+        elections = data["health_coverage_elections"]
+        self.assertEqual(len(elections), 3)
+        self.assertEqual(elections[0]["coverage_level_code"], "IND")
+        self.assertEqual(elections[0]["coverage_end_dt"], "20241231")
+        hlt_refs = {r["ref_qualifier"]: r["ref_value"] for r in elections[0]["references"]}
+        self.assertEqual(hlt_refs.get("X9"), "PLAN ASSIGNED POLICY ID")
+
+        # LS/LE 2700 reporting
+        cats = data["reporting_categories"]
+        self.assertGreaterEqual(len(cats), 10)
+        by_name = {c["name"]: c for c in cats}
+        self.assertIn("FAM IND", by_name)
+        self.assertEqual(by_name["FAM IND"]["references"][0]["ref_value"], "F")
+        self.assertIn("AID CAT CODE", by_name)
+        self.assertEqual(by_name["AID CAT CODE"]["references"][0]["ref_value"], "91")
+
+        # Y2 MCO should appear in related parties
+        self.assertTrue(any(p["entity_identifier_code"] == "Y2" for p in data["related_parties"]))
+
+    def test_ins_count_still_matches(self):
+        for name in ("EDI_834.txt", "834_test.txt"):
+            edi = _load(name)
+            ins = len([s for s in edi.data if s._name == "INS"])
+            self.assertEqual(ins, len(hm.from_edi(edi)), msg=name)
+
+    def test_json_serializable(self):
+        for name in ("EDI_834.txt", "834_test.txt"):
+            payload = hm.from_edi(_load(name))[0].to_json()
+            json.dumps(payload)  # must not raise
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Improves HIPAA **834** (`MemberEnrollment`) parsing so the accelerator’s sample 834s map more completely—closer to how 837 handlers already expose structured fields.

This does **not** attempt full companion-guide validation or clearinghouse behavior; it extends the existing handler for practical enrollment analytics.

### What’s included
- Transaction header: `BGN`, `QTY`, sponsor `N1*P5`, insurer `N1*IN`
- Member `REF` / qualifier-aware `DTP` (e.g. eligibility begin `356`)
- INS relationship + maintenance decode tables
- Related parties (`NM1*70` / `QD` / `Y2`)
- HD coverage level + HD `REF`s; LS/LE `2700` reporting categories (without polluting HD loops)
- Field mapping CSV updates
- Spark-free unit tests (`tests/test_enrollment_fields.py`) against existing sample files
- Package bump to `0.0.10a1`

### Out of scope (intentionally)
- Trading-partner companion-guide rule packs
- 999/TA1 acknowledgements
- Lakehouse/demo pipeline code (kept outside this library)

## Test plan
- [x] `PYTHONPATH=. python3 -m unittest tests.test_enrollment_fields -v`
- [x] Optional: existing 834 sample notebooks still parse; INS count == enrollment row count
- [x] Confirm CLA signed for contributor

## Notes for maintainers
Happy to adjust naming, decode tables, or drop any field that you’d rather keep in a downstream extension.